### PR TITLE
Security Fix: Add rel="noopener noreferrer" to external links

### DIFF
--- a/script.js
+++ b/script.js
@@ -216,14 +216,17 @@ function Project(props) {
   }), props.site == "" ? /*#__PURE__*/React.createElement("a", {
     className: "site button",
     href: props.github,
-    target: "_blank"
+    target: "_blank",
+    rel: "noopener noreferrer"
   }, "See it on GitHub") : /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("a", {
     className: "site site-left button",
     href: props.github,
-    target: "_blank"
+    target: "_blank",
+    rel: "noopener noreferrer"
   }, "See it on GitHub"), /*#__PURE__*/React.createElement("a", {
     className: "site site-right button",
     href: props.site,
-    target: "_blank"
+    target: "_blank",
+    rel: "noopener noreferrer"
   }, "Try it out!"))));
 }

--- a/src/script.js
+++ b/src/script.js
@@ -172,10 +172,10 @@ function Project(props) {
 				
 				<p className="desc" dangerouslySetInnerHTML={{ __html: props.desc.replace(/\\n/g, '<br />') }}></p>
 				{props.site == ""
-					? <a className="site button" href={props.github} target="_blank">See it on GitHub</a>
+					? <a className="site button" href={props.github} target="_blank" rel="noopener noreferrer">See it on GitHub</a>
 					: <div>
-						<a className="site site-left button" href={props.github} target="_blank">See it on GitHub</a>
-						<a className="site site-right button" href={props.site} target="_blank">Try it out!</a>
+						<a className="site site-left button" href={props.github} target="_blank" rel="noopener noreferrer">See it on GitHub</a>
+						<a className="site site-right button" href={props.site} target="_blank" rel="noopener noreferrer">Try it out!</a>
 					  </div>
 				}
 			</div>


### PR DESCRIPTION
This PR addresses a security vulnerability where external links opening in a new tab (`target="_blank"`) were missing the `rel="noopener noreferrer"` attribute. This omission could allow the opened page to manipulate the original page via the `window.opener` object (Reverse Tabnabbing).

Changes:
- Added `rel="noopener noreferrer"` to all `<a>` tags with `target="_blank"` in `src/script.js`.
- Rebuilt the project using `./babel.sh` to update the production artifact `script.js`.

Verification:
- Manually verified the fix using a reproduction script and visually inspected the changes.
- Automated Playwright tests confirmed the presence of the `rel` attribute on all relevant links.

---
*PR created automatically by Jules for task [10372470139733916649](https://jules.google.com/task/10372470139733916649) started by @amot-dev*